### PR TITLE
insert actionlog after response!

### DIFF
--- a/src/Http/Middleware/ActionLogger.php
+++ b/src/Http/Middleware/ActionLogger.php
@@ -9,12 +9,14 @@ class ActionLogger
 {
     public function handle($request, Closure $next)
     {
-        ActionLog::create([
+        $actionLog = ActionLog::make([
             'user_id' => $request->user()->id,
             'url' => $request->url(),
             'route' => $request->route()->getName(),
             'method' => $request->method(),
         ]);
+
+        dispatch(fn () => $actionLog->save())->afterResponse();
 
         return $next($request);
     }

--- a/src/Http/Middleware/ActionLogger.php
+++ b/src/Http/Middleware/ActionLogger.php
@@ -9,14 +9,14 @@ class ActionLogger
 {
     public function handle($request, Closure $next)
     {
-        $actionLog = ActionLog::make([
-            'user_id' => $request->user()->id,
+        $attributes = [
             'url' => $request->url(),
+            'user_id' => $request->user()->id,
             'route' => $request->route()->getName(),
             'method' => $request->method(),
-        ]);
+        ];
 
-        dispatch(fn () => $actionLog->save())->afterResponse();
+        dispatch(fn () => ActionLog::create($attributes))->afterResponse();
 
         return $next($request);
     }

--- a/src/Http/Middleware/ActionLogger.php
+++ b/src/Http/Middleware/ActionLogger.php
@@ -9,14 +9,14 @@ class ActionLogger
 {
     public function handle($request, Closure $next)
     {
-        $attributes = [
-            'url' => $request->url(),
+        $actionLog = ActionLog::make([
             'user_id' => $request->user()->id,
+            'url' => $request->url(),
             'route' => $request->route()->getName(),
             'method' => $request->method(),
-        ];
+        ]);
 
-        dispatch(fn () => ActionLog::create($attributes))->afterResponse();
+        dispatch(fn () => $actionLog->save())->afterResponse();
 
         return $next($request);
     }


### PR DESCRIPTION
I noticed that sometimes we waste time on inserting actingLog! I guess we can insert it after the response!
![image](https://user-images.githubusercontent.com/10864136/101147883-2f9cc500-3632-11eb-8f00-aed66a1d7209.png)
