### PR TITLE
Laravel 10 Fix

### DIFF
--- a/src/AppServiceProvider.php
+++ b/src/AppServiceProvider.php
@@ -7,11 +7,15 @@ use LaravelEnso\ActionLogger\Http\Middleware\ActionLogger;
 
 class AppServiceProvider extends ServiceProvider
 {
-    public function boot()
+    public function boot(): void
     {
         $this->app['router']->aliasMiddleware('action-logger', ActionLogger::class);
 
-        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+        $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
+    }
 
+    public function register(): void
+    {
+        $this->app->singleton(ActionLogger::class);
     }
 }

--- a/src/AppServiceProvider.php
+++ b/src/AppServiceProvider.php
@@ -11,11 +11,6 @@ class AppServiceProvider extends ServiceProvider
     {
         $this->app['router']->aliasMiddleware('action-logger', ActionLogger::class);
 
-        $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
-    }
-
-    public function register(): void
-    {
-        $this->app->singleton(ActionLogger::class);
+        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
     }
 }

--- a/src/Http/Middleware/ActionLogger.php
+++ b/src/Http/Middleware/ActionLogger.php
@@ -9,24 +9,19 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ActionLogger
 {
-    private ActionLog $log;
-
     public function handle(Request $request, Closure $next): Response
     {
-        $this->log = ActionLog::make([
-            'user_id' => $request->user()->id,
-            'url' => $request->url(),
-            'route' => $request->route()->getName(),
-            'method' => $request->method(),
-        ]);
-
         return $next($request);
     }
 
     public function terminate(Request $request, Response $response): void
     {
-        $this->log->fill([
+        ActionLog::create([
+            'user_id' => $request->user()->id,
+            'url' => $request->url(),
+            'route' => $request->route()->getName(),
+            'method' => $request->method(),
             'duration' => min(999.999, microtime(true) - LARAVEL_START),
-        ])->save();
+        ]);
     }
 }


### PR DESCRIPTION
Since this [commit](https://github.com/laravel/framework/pull/46806/files), the current Action Logging approach is no longer functional. This MR aims to address that, should be pretty self-explanatory.

Registering the Middleware as a singleton ensures that we will receive the same instance when terminate() is being called. This approach was inspired from the official Laravel [documentation](https://laravel.com/docs/10.x/middleware#terminable-middleware).

